### PR TITLE
feat(api): add message collection service

### DIFF
--- a/trading-backend/Cargo.toml
+++ b/trading-backend/Cargo.toml
@@ -14,3 +14,6 @@ tower-http = { version = "0.5", features = ["cors", "trace"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 anyhow = "1"
+chrono = { version = "0.4", features = ["serde"] }
+reqwest = { version = "0.11", features = ["json"] }
+once_cell = "1"

--- a/trading-backend/src/api/mod.rs
+++ b/trading-backend/src/api/mod.rs
@@ -1,5 +1,7 @@
 use axum::{extract::Json, http::StatusCode};
 use serde::{Deserialize, Serialize};
+use chrono::Utc;
+
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Order {
@@ -54,4 +56,102 @@ pub async fn create_order(
         status: "pending".to_string(),
     };
     (StatusCode::CREATED, Json(order))
+}
+
+// Message-related handlers - in-memory storage for MVP
+use std::sync::Mutex;
+use once_cell::sync::Lazy;
+
+static MESSAGES: Lazy<Mutex<Vec<Message>>> = Lazy::new(|| {
+    Mutex::new(vec![
+        Message {
+            id: 1,
+            content: "BTC price update: $50000".to_string(),
+            message_type: "crypto_price".to_string(),
+            source: "binance".to_string(),
+            created_at: Utc::now(),
+        },
+        Message {
+            id: 2,
+            content: "ETH price update: $3000".to_string(),
+            message_type: "crypto_price".to_string(),
+            source: "binance".to_string(),
+            created_at: Utc::now(),
+        },
+    ])
+});
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Message {
+    pub id: i64,
+    pub content: String,
+    pub message_type: String,
+    pub source: String,
+    pub created_at: chrono::DateTime<Utc>,
+}
+
+pub async fn list_messages() -> Json<Vec<Message>> {
+    let messages = MESSAGES.lock().unwrap();
+    Json(messages.clone())
+}
+
+// Fetch crypto prices from public API and create messages
+pub async fn fetch_crypto_prices() -> (StatusCode, Json<Vec<Message>>) {
+    let client = reqwest::Client::new();
+    
+    // Fetch BTC price from CoinGecko API (free, no API key needed)
+    let btc_response = client
+        .get("https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd")
+        .send()
+        .await;
+    
+    let mut new_messages: Vec<Message> = Vec::new();
+    let mut next_id = MESSAGES.lock().unwrap().len() as i64 + 1;
+    
+    if let Ok(response) = btc_response {
+        if let Ok(data) = response.json::<serde_json::Value>().await {
+            if let Some(btc_price) = data.get("bitcoin").and_then(|v| v.get("usd")) {
+                let price = btc_price.as_f64().unwrap_or(0.0);
+                let content = format!("BTC price update: ${}", price);
+                new_messages.push(Message {
+                    id: next_id,
+                    content,
+                    message_type: "crypto_price".to_string(),
+                    source: "coingecko".to_string(),
+                    created_at: Utc::now(),
+                });
+                next_id += 1;
+            }
+        }
+    }
+    
+    // Fetch ETH price
+    let eth_response = client
+        .get("https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd")
+        .send()
+        .await;
+    
+    if let Ok(response) = eth_response {
+        if let Ok(data) = response.json::<serde_json::Value>().await {
+            if let Some(eth_price) = data.get("ethereum").and_then(|v| v.get("usd")) {
+                let price = eth_price.as_f64().unwrap_or(0.0);
+                let content = format!("ETH price update: ${}", price);
+                new_messages.push(Message {
+                    id: next_id,
+                    content,
+                    message_type: "crypto_price".to_string(),
+                    source: "coingecko".to_string(),
+                    created_at: Utc::now(),
+                });
+            }
+        }
+    }
+    
+    // Store the new messages
+    if !new_messages.is_empty() {
+        let mut messages = MESSAGES.lock().unwrap();
+        messages.extend(new_messages.clone());
+    }
+    
+    (StatusCode::OK, Json(new_messages))
 }

--- a/trading-backend/src/db.rs
+++ b/trading-backend/src/db.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+use chrono::{DateTime, Utc};
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct Message {
+    pub id: i64,
+    pub content: String,
+    pub message_type: String,
+    pub source: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CryptoPrice {
+    pub symbol: String,
+    pub price: f64,
+}
+
+// Database initialization SQL
+pub const MESSAGES_TABLE_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS messages (
+    id SERIAL PRIMARY KEY,
+    content TEXT NOT NULL,
+    message_type VARCHAR(50) NOT NULL,
+    source VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+"#;

--- a/trading-backend/src/main.rs
+++ b/trading-backend/src/main.rs
@@ -22,6 +22,8 @@ async fn main() {
         .route("/api/health", get(api::health))
         .route("/api/orders", get(api::list_orders))
         .route("/api/orders", post(api::create_order))
+        .route("/api/v1/messages", get(api::list_messages))
+        .route("/api/v1/messages/fetch", get(api::fetch_crypto_prices))
         .layer(cors);
 
     let addr = SocketAddr::from(([0, 0, 0, 0], 8080));


### PR DESCRIPTION
## Summary

Implement Issue #17: Message Collection Service

- Add Message struct with id, content, message_type, source, created_at fields
- Add GET /api/v1/messages endpoint to retrieve stored messages  
- Add GET /api/v1/messages/fetch endpoint to fetch crypto prices from CoinGecko API
- Add in-memory message storage for MVP (can be extended to PostgreSQL)
- Add db.rs with database schema SQL for messages table
- Add required dependencies: chrono, reqwest, once_cell

## Testing

The API can be tested with:
- GET /api/v1/messages - returns all stored messages
- GET /api/v1/messages/fetch - fetches BTC/ETH prices from CoinGecko and stores them