### PR TITLE
feat(auth): add JWT authentication middleware (Issue #31)

### DIFF
--- a/trading-backend/src/auth/middleware.rs
+++ b/trading-backend/src/auth/middleware.rs
@@ -1,0 +1,43 @@
+use axum::{
+    extract::Request,
+    http::StatusCode,
+    middleware::Next,
+    response::Response,
+};
+use jsonwebtoken::{decode, DecodingKey, Validation};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Claims {
+    pub sub: String,
+    pub user_id: i64,
+    pub exp: i64,
+}
+
+const JWT_SECRET: &str = "trading_system_secret_key_change_in_production";
+
+pub async fn auth_middleware(mut req: Request, next: Next) -> Result<Response, StatusCode> {
+    let auth_header = req
+        .headers()
+        .get("authorization")
+        .and_then(|v| v.to_str().ok());
+
+    if let Some(auth_header) = auth_header {
+        if let Some(token) = auth_header.strip_prefix("Bearer ") {
+            match decode::<Claims>(
+                token,
+                &DecodingKey::from_secret(JWT_SECRET.as_bytes()),
+                &Validation::default(),
+            ) {
+                Ok(token_data) => {
+                    // Add user info to request extensions
+                    req.extensions_mut().insert(token_data.claims);
+                    return Ok(next.run(req).await);
+                }
+                Err(_) => return Err(StatusCode::UNAUTHORIZED),
+            }
+        }
+    }
+
+    Err(StatusCode::UNAUTHORIZED)
+}

--- a/trading-backend/src/auth/mod.rs
+++ b/trading-backend/src/auth/mod.rs
@@ -1,7 +1,10 @@
+pub mod middleware;
+
 use axum::{
     extract::State,
     http::StatusCode,
     response::Json,
+    Extension,
 };
 use serde::{Deserialize, Serialize};
 use jsonwebtoken::{encode, decode, Header, Validation, EncodingKey, DecodingKey};
@@ -9,8 +12,9 @@ use chrono::{Utc, Duration};
 use bcrypt::{hash, verify};
 use sqlx::Pool;
 use sqlx::Postgres;
+use std::sync::Arc;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Claims {
     pub sub: String,
     pub user_id: i64,
@@ -125,4 +129,9 @@ pub async fn login(
         user_id: user.0,
         username: user.1,
     }))
+}
+
+/// Extract the current user from request extensions
+pub fn get_current_user(Extension(claims): Extension<Claims>) -> Claims {
+    claims
 }


### PR DESCRIPTION
## Summary
Add JWT authentication to the backend with the following changes:

### Changes Made
1. **Added auth middleware** ()
   - Bearer token validation middleware
   - Returns 401 Unauthorized if token is missing/invalid
   - Attaches claims to request extensions on success

2. **Updated auth module** ()
   - Added  module export
   - Added  helper to extract claims from requests

3. **Auth endpoints already in place** (from previous work):
   -  - POST - Register new user
   -  - POST - Login and get JWT token

### Usage
To protect a route, add the middleware:
```rust
.route("/protected", get(handler))
.layer(axum::middleware::from_fn(auth::middleware::auth_middleware))
```

To get current user in handler:
```rust
pub async fn handler(Extension(claims): Extension<auth::Claims>) { ... }
```

Closes #31